### PR TITLE
Revised PHPWrapper

### DIFF
--- a/API/clients/PHPwrapper/GetResponseAPI.class.php
+++ b/API/clients/PHPwrapper/GetResponseAPI.class.php
@@ -482,11 +482,11 @@ class GetResponse
 	 * @return string JSON encoded string
 	 * @access private
 	 */
-	private function prepRequest($method, $params = null)
+	private function prepRequest($method, $params = null, $id = null)
 	{
 		$array = array($this->apiKey);
 		if(!is_null($params)) $array[1] = $params;
-		$request = json_encode(array('method' => $method, 'params' => $array));
+		$request = json_encode(array('method' => $method, 'params' => $array, 'id' => $id));
 		return $request;
 	}
 	
@@ -506,7 +506,7 @@ class GetResponse
 		$response = json_decode(curl_exec($handle));
 		if(curl_error($handle)) trigger_error(curl_error($handle), E_USER_ERROR);
 		$httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-		if($httpCode != '200') trigger_error('API call failed. Server returned status code '.$httpCode, E_USER_ERROR);
+		if(!(($httpCode == '200') || ($httpCode == '204'))) trigger_error('API call failed. Server returned status code '.$httpCode, E_USER_ERROR);
 		curl_close($handle);
 		if(!$response->error) return $response->result;
 	}


### PR DESCRIPTION
The PHPWrapper is no longer being supported by Ben Tadiar. I emailed him at ben@bentadiar.co.uk and his response was: "I no longer maintain that library, and transferred ownership of the
codebase to GetResponse a while back, hence being on their GitHub account and not mine."

The PHPWrapper is broken with the new changes that were implemented on 11-30 enabling Notifications (HTTP 204 Response). 

This patch to the PHPWrapper not only fixes these problems, but also includes numerous new PHP functions that implement further aspects of the GetResponse API.

Please email me at robert@abundantdesigns.com with any questions. Thank you!
