### PR TITLE
Removing hidden character

### DIFF
--- a/API/lib/jsonRPCClient.php
+++ b/API/lib/jsonRPCClient.php
@@ -272,7 +272,7 @@ class jsonRPCClient
         // get starttime
         $startTime = empty($startTime) ? array_sum(explode(' ', microtime())) : $startTime;
         if (true === $pShow and !empty($debug))
-        {
+        {
             // get endtime
             $endTime = array_sum(explode(' ', microtime()));
             // performance summary


### PR DESCRIPTION
Removing hidden character that cause PHP warning because the character is interpreted as output content
